### PR TITLE
Improve the extraction of the envelope address

### DIFF
--- a/SendGrid.pm
+++ b/SendGrid.pm
@@ -63,6 +63,19 @@ sub parsed_metadata {
 
   my $envfrom = $pms->get("EnvelopeFrom:addr", undef);
 
+  if ($envfrom) {
+    dbg("found Envelope-From in the headers");
+  } else {
+    my $relay = $pms->{relays_external}->[0];
+    if (defined $relay) {
+      $envfrom = $relay->{envfrom};
+      dbg("found Envelope-From in first external Received header");
+    } else {
+      dbg("could not find Envelope-From, exiting");
+      return;
+    }
+  }
+
   if($envfrom =~ /^bounces\+(\d+)\-/) {
     $sendgrid_id = $1;
     # dbg("ENVFROM: $envfrom ID: $sendgrid_id");

--- a/SendGrid.pm
+++ b/SendGrid.pm
@@ -32,7 +32,7 @@ Extract SendGrid ID from a message to the tag SENDGRIDID, this tag can be used w
 =cut
 
 package Mail::SpamAssassin::Plugin::SendGrid;
-my $VERSION = 0.3;
+my $VERSION = 0.4;
 
 use strict;
 use Mail::SpamAssassin::Plugin;


### PR DESCRIPTION
In some case the envelope cannot be found in the headers, and the $envfrom variable it passed to the regex check uninitialized. This patch adds the ability to determine the envelope from the received header if not found using the first extraction. It also prevents passing the uninitialized variable to the regex.